### PR TITLE
build(deps): fix missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.0",
 		"@types/node": "^12.11.7",
+		"@types/react": "^17.0.0",
 		"@types/vscode": "^1.50.0",
 		"eslint": "^7.9.0",
 		"eslint-config-prettier": "^6.15.0",
@@ -137,6 +138,8 @@
 		"react-dom": "^17.0.1",
 		"react-icons": "^3.11.0",
 		"vscode-languageclient": "^6.1.3",
+		"vscode-languageserver": "^6.1.1",
+		"vscode-languageserver-textdocument": "^1.0.1",
 		"wmlandscape": "^1.223.0"
 	},
 	"browserslist": {


### PR DESCRIPTION
While adding your extension to the `open-vsx/publish-extension`, (open-vsx/publish-extensions#218) we ran into a problem during compile time, some runtime dependencies were missing and at least on my build-system there was a problem with different react-types. Should also help working towards #3. 

This PR should fix both errors:

- @types/react dependency (resolves react compile time error)
- vscode-languageserver
- vscode-languageserver-textdocument