### PR TITLE
ci(github): publish action

### DIFF
--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Deploy Extension to Open-VSX and VSCode Marketplace
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          packagePath: ''

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.0",
 		"@types/node": "^12.11.7",
+		"@types/react": "^17.0.0",
 		"@types/vscode": "^1.50.0",
 		"eslint": "^7.9.0",
 		"eslint-config-prettier": "^6.15.0",
@@ -137,6 +138,8 @@
 		"react-dom": "^17.0.1",
 		"react-icons": "^3.11.0",
 		"vscode-languageclient": "^6.1.3",
+		"vscode-languageserver": "^6.1.1",
+		"vscode-languageserver-textdocument": "^1.0.1",
 		"wmlandscape": "^1.223.0"
 	},
 	"browserslist": {


### PR DESCRIPTION
This adds a GitHub workflow which should publish the extension whenever a new tag is added in the repository. This implements #3.

Before it works, you will have to claim your namespace in Open-VSX and set-up the two secrets needed for Open-VSX and VSCode Marketplace in GitHub. See details here: https://github.com/HaaLeo/publish-vscode-extension#readme

Since I'm such a loser at working with git, it *also* incorporates the changes needed for successful builds I've proposed via PR #7 🤣😊🙄: 

- @types/react dependency (resolves react compile time error)
- vscode-languageserver
- vscode-languageserver-textdocument
